### PR TITLE
Improve ParseInternal performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## TypeScript `nameof` [Unreleased]
+### Updated
+  - Improved performance ([#6](https://github.com/typescript-nameof/nameof/pull/6))  
+    Thanks, [@lahma](https://github.com/lahma)!
 
 [Show differences](https://github.com/typescript-nameof/nameof/compare/v0.0.7...dev)
 

--- a/packages/nameof/src/Transformation/TypeScriptAdapter.cts
+++ b/packages/nameof/src/Transformation/TypeScriptAdapter.cts
@@ -275,6 +275,7 @@ export class TypeScriptAdapter extends Adapter<TypeScriptFeatures, ts.Node, ts.N
     protected ParseInternal(item: ts.Node, context: ITypeScriptContext): ParsedNode<ts.Node>
     {
         const typeScript = this.TypeScript;
+
         if (this.IsCallExpression(item))
         {
             return new CallExpressionNode<ts.Node>(


### PR DESCRIPTION
I was trying to figure out why nameof was slowing down our WebPack processing so much. Did a quick code review and found out that `ParseInternal` which is on hot path was always allocating new array to do checks. This PR tries to improve things. Saw about 50% reduction in processing time for a large set of TypeScript files.

I think there's still room for improvement as 
* without these changes processing takes `118982 ms` 
* with changes processing takes `60044 ms` 
* without nameof configuration for the WebPack it takes `19428 ms`.

Summary of changes:

* use only-once instantiated Set for fast lookup instead of creating slower array every time
* check two items with simple or instead of an array
* use local TypeScript retrieved from getter instead of multiple invokes